### PR TITLE
Load Firebase config from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment variables for the AudioChat frontend
+# Copy this file to .env and fill in your Firebase configuration
+
+# Firebase configuration
+REACT_APP_FIREBASE_API_KEY=
+REACT_APP_FIREBASE_AUTH_DOMAIN=
+REACT_APP_FIREBASE_PROJECT_ID=
+REACT_APP_FIREBASE_STORAGE_BUCKET=
+REACT_APP_FIREBASE_MESSAGING_SENDER_ID=
+REACT_APP_FIREBASE_APP_ID=
+
+# Backend API URL
+REACT_APP_API_URL=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .venv/
+
+# Local environment files
 .env
 
 # VSCode

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "wavesurfer.js": "^6.6.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "node -r dotenv/config node_modules/react-scripts/scripts/start.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/components/auth/AutoLogin.js
+++ b/src/components/auth/AutoLogin.js
@@ -5,12 +5,12 @@ import './AuthForms.css';
 
 // Firebase configuration for the AudioChat project
 const firebaseConfig = {
-  apiKey: "AIzaSyDJQw_TKGUQJGGwzS8LG9CZ_9QXW9Jj4Vc",
-  authDomain: "audiochat-466211.firebaseapp.com",
-  projectId: "audiochat-466211",
-  storageBucket: "audiochat-466211.appspot.com",
-  messagingSenderId: "484800218204",
-  appId: "1:484800218204:web:3b5e9f9d7d56a9e9f9d7d5"
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID
 };
 
 // Mock user data for direct access

--- a/src/components/auth/DirectLogin.js
+++ b/src/components/auth/DirectLogin.js
@@ -5,12 +5,12 @@ import './AuthForms.css';
 
 // Firebase configuration for the AudioChat project
 const firebaseConfig = {
-  apiKey: "AIzaSyDJQw_TKGUQJGGwzS8LG9CZ_9QXW9Jj4Vc",
-  authDomain: "audiochat-466211.firebaseapp.com",
-  projectId: "audiochat-466211",
-  storageBucket: "audiochat-466211.appspot.com",
-  messagingSenderId: "484800218204",
-  appId: "1:484800218204:web:3b5e9f9d7d56a9e9f9d7d5"
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID
 };
 
 function DirectLogin() {


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders for frontend variables
- load Firebase config from `process.env` in auth components
- use dotenv in the start script
- ignore real `.env` files

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa7ca2b9c832c89b98522c4114802