### PR TITLE
Switch emoji icons to react-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react-responsive": "^9.0.2",
         "react-router-dom": "^7.7.0",
         "react-scripts": "^5.0.1",
-        "wavesurfer.js": "^6.6.4"
+        "wavesurfer.js": "^6.6.4",
+        "react-icons": "^4.12.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react-responsive": "^9.0.2",
     "react-router-dom": "^7.7.0",
     "react-scripts": "^5.0.1",
-    "wavesurfer.js": "^6.6.4"
+    "wavesurfer.js": "^6.6.4",
+    "react-icons": "^4.12.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/AudioProcessingInterface.js
+++ b/src/components/AudioProcessingInterface.js
@@ -8,6 +8,7 @@ import ParameterAdjuster from './ParameterAdjuster';
 import AudioEditor from './AudioEditor';
 import SpectrumAnalyzer from './SpectrumAnalyzer';
 import AudioExport from './AudioExport';
+import { FaTimesCircle } from 'react-icons/fa';
 import { useAuth } from '../context/AuthContext';
 import uploadService from '../services/upload';
 import { getAudioWaveform } from '../services/authenticatedApi';
@@ -124,7 +125,9 @@ function AudioProcessingInterface() {
     <div className="audio-processing-interface">
       {uploadError && (
         <div className="error-message">
-          <p>❌ {uploadError}</p>
+          <p>
+            <FaTimesCircle aria-label="Error" /> {uploadError}
+          </p>
           <button onClick={() => setUploadError(null)}>Dismiss</button>
         </div>
       )}

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import { useAuth } from '../context/AuthContext';
 import uploadService from '../services/upload';
 import './FileUpload.css';
+import { FaMusic } from 'react-icons/fa';
 
 function FileUpload({ onUploadComplete, onUploadError }) {
   const { isAuthenticated } = useAuth();
@@ -113,7 +114,9 @@ function FileUpload({ onUploadComplete, onUploadError }) {
           </div>
         ) : (
           <div className="upload-prompt">
-            <div className="upload-icon">🎵</div>
+            <div className="upload-icon">
+              <FaMusic aria-label="Upload" />
+            </div>
             <h3>Upload Audio File</h3>
             <p>Drag and drop your audio file here, or click to browse</p>
             <p className="file-info">Supported formats: WAV, MP3, OGG, FLAC, AAC, M4A (max 50MB)</p>

--- a/src/components/MainLayout.js
+++ b/src/components/MainLayout.js
@@ -4,13 +4,17 @@ import { useAuth } from '../context/AuthContext';
 import ThemeToggle from './ThemeToggle';
 import './MainLayout.css';
 
-// Icons (simple text-based for now)
-const HomeIcon = () => <span>🏠</span>;
-const ChatIcon = () => <span>💬</span>;
-const AudioIcon = () => <span>🎵</span>;
-const SettingsIcon = () => <span>⚙️</span>;
-const ExtensionsIcon = () => <span>🧩</span>;
-const HelpIcon = () => <span>❓</span>;
+// Icons from react-icons
+import {
+  FaHome,
+  FaComments,
+  FaMusic,
+  FaCog,
+  FaPuzzlePiece,
+  FaQuestionCircle,
+  FaUser,
+  FaSignOutAlt,
+} from 'react-icons/fa';
 
 const MainLayout = ({ children }) => {
   const { user, signOut } = useAuth();
@@ -58,22 +62,22 @@ const MainLayout = ({ children }) => {
         
         <SidebarSection>
           <SidebarNav>
-            <SidebarNavItem 
-              icon={<HomeIcon />} 
+            <SidebarNavItem
+              icon={<FaHome aria-label="Home" />}
               active={activeItem === 'home'}
               onClick={() => handleNavItemClick('home')}
             >
               Home
             </SidebarNavItem>
-            <SidebarNavItem 
-              icon={<ChatIcon />} 
+            <SidebarNavItem
+              icon={<FaComments aria-label="Chats" />}
               active={activeItem === 'chats'}
               onClick={() => handleNavItemClick('chats')}
             >
               Chats
             </SidebarNavItem>
-            <SidebarNavItem 
-              icon={<AudioIcon />} 
+            <SidebarNavItem
+              icon={<FaMusic aria-label="Audio" />}
               active={activeItem === 'audio'}
               onClick={() => handleNavItemClick('audio')}
             >
@@ -84,22 +88,22 @@ const MainLayout = ({ children }) => {
         
         <SidebarSection title="Tools">
           <SidebarNav>
-            <SidebarNavItem 
-              icon={<ExtensionsIcon />} 
+            <SidebarNavItem
+              icon={<FaPuzzlePiece aria-label="Extensions" />}
               active={activeItem === 'extensions'}
               onClick={() => handleNavItemClick('extensions')}
             >
               Extensions
             </SidebarNavItem>
-            <SidebarNavItem 
-              icon={<SettingsIcon />} 
+            <SidebarNavItem
+              icon={<FaCog aria-label="Settings" />}
               active={activeItem === 'settings'}
               onClick={() => handleNavItemClick('settings')}
             >
               Settings
             </SidebarNavItem>
-            <SidebarNavItem 
-              icon={<HelpIcon />} 
+            <SidebarNavItem
+              icon={<FaQuestionCircle aria-label="Help" />}
               active={activeItem === 'help'}
               onClick={() => handleNavItemClick('help')}
             >
@@ -114,13 +118,13 @@ const MainLayout = ({ children }) => {
           </div>
           <div className="user-profile">
             <div className="user-avatar">
-              <span>👤</span>
+              <FaUser aria-label="User" />
             </div>
             <div className="user-info">
               <div className="user-name">{user?.email || 'User'}</div>
               <div className="user-status">
                 <button className="logout-button" onClick={handleLogout}>
-                  Sign Out
+                  <FaSignOutAlt aria-label="Sign Out" /> Sign Out
                 </button>
               </div>
             </div>

--- a/src/components/ProfileMenu.js
+++ b/src/components/ProfileMenu.js
@@ -1,5 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './ProfileMenu.css';
+import {
+  FaCog,
+  FaSlidersH,
+  FaDatabase,
+  FaKey,
+  FaPuzzlePiece,
+  FaQuestionCircle,
+  FaSignOutAlt,
+} from 'react-icons/fa';
 
 function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -52,7 +61,7 @@ function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
                 setIsOpen(false);
               }}
             >
-              <span className="menu-icon">⚙️</span>
+              <FaCog aria-label="Settings" className="menu-icon" />
               Settings
             </button>
             <button 
@@ -62,7 +71,7 @@ function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
                 setIsOpen(false);
               }}
             >
-              <span className="menu-icon">🎨</span>
+              <FaSlidersH aria-label="Appearance" className="menu-icon" />
               Appearance
             </button>
             <button 
@@ -72,7 +81,7 @@ function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
                 setIsOpen(false);
               }}
             >
-              <span className="menu-icon">🗄️</span>
+              <FaDatabase aria-label="Database" className="menu-icon" />
               Database
             </button>
             <button 
@@ -82,7 +91,7 @@ function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
                 setIsOpen(false);
               }}
             >
-              <span className="menu-icon">🔑</span>
+              <FaKey aria-label="API Keys" className="menu-icon" />
               API Keys
             </button>
             <button 
@@ -92,7 +101,7 @@ function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
                 setIsOpen(false);
               }}
             >
-              <span className="menu-icon">🧩</span>
+              <FaPuzzlePiece aria-label="Extensions" className="menu-icon" />
               Extensions
             </button>
             <button 
@@ -102,7 +111,7 @@ function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
                 setIsOpen(false);
               }}
             >
-              <span className="menu-icon">❓</span>
+              <FaQuestionCircle aria-label="Help" className="menu-icon" />
               Help & FAQ
             </button>
           </div>
@@ -115,7 +124,7 @@ function ProfileMenu({ onOpenPage = () => {}, onLogout = () => {} }) {
                 setIsOpen(false);
               }}
             >
-              <span className="menu-icon">🚪</span>
+              <FaSignOutAlt aria-label="Log out" className="menu-icon" />
               Log out
             </button>
           </div>

--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTheme } from '../context/ThemeContext';
 import './ThemeToggle.css';
+import { FaSun, FaMoon } from 'react-icons/fa';
 
 const ThemeToggle = () => {
   const { isDarkMode, toggleTheme } = useTheme();
@@ -12,9 +13,9 @@ const ThemeToggle = () => {
       title={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
     >
       {isDarkMode ? (
-        <span className="theme-toggle-icon">☀️</span>
+        <FaSun aria-label="Light mode" className="theme-toggle-icon" />
       ) : (
-        <span className="theme-toggle-icon">🌙</span>
+        <FaMoon aria-label="Dark mode" className="theme-toggle-icon" />
       )}
       <span className="theme-toggle-text">
         {isDarkMode ? "Light Mode" : "Dark Mode"}

--- a/src/components/UserFiles.js
+++ b/src/components/UserFiles.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import uploadService from '../services/upload';
 import './UserFiles.css';
+import { FaFolder, FaMusic } from 'react-icons/fa';
 
 function UserFiles({ onFileSelect }) {
   const { isAuthenticated } = useAuth();
@@ -109,11 +110,11 @@ function UserFiles({ onFileSelect }) {
                     ⏱️ {formatDuration(file.duration)}
                   </span>
                   <span className="file-size">
-                    📁 {formatFileSize(file.size)}
+                    <FaFolder aria-label="File size" /> {formatFileSize(file.size)}
                   </span>
                   {file.sample_rate && (
                     <span className="file-sample-rate">
-                      🎵 {file.sample_rate} Hz
+                      <FaMusic aria-label="Sample rate" /> {file.sample_rate} Hz
                     </span>
                   )}
                 </div>

--- a/src/components/pages/DatabaseConfigPage.js
+++ b/src/components/pages/DatabaseConfigPage.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import databaseConfig, { DB_PROVIDERS } from '../../config/database';
 import './Pages.css';
+import { FaCheckCircle } from 'react-icons/fa';
 
 function DatabaseConfigPage() {
   const [selectedProvider, setSelectedProvider] = useState(databaseConfig.getProvider());
@@ -324,7 +325,7 @@ function DatabaseConfigPage() {
         <div className="settings-section">
           <h4>Connection Status</h4>
           <div className="status-indicator success">
-            ✅ Connected to {selectedProvider === DB_PROVIDERS.SUPABASE ? 'Supabase' : 'Firebase'}
+            <FaCheckCircle aria-label="Connected" /> Connected to {selectedProvider === DB_PROVIDERS.SUPABASE ? 'Supabase' : 'Firebase'}
           </div>
         </div>
       )}

--- a/src/components/pages/SettingsPage.js
+++ b/src/components/pages/SettingsPage.js
@@ -4,6 +4,7 @@ import ApiKeysPage from './ApiKeysPage';
 import HelpFaqPage from './HelpFaqPage';
 import DatabaseConfigPage from './DatabaseConfigPage';
 import './Pages.css';
+import { FaSlidersH, FaDatabase, FaKey, FaQuestionCircle } from 'react-icons/fa';
 
 function SettingsPage({ onClose, initialTab = 'appearance' }) {
   const [activePage, setActivePage] = useState(initialTab);
@@ -33,28 +34,28 @@ function SettingsPage({ onClose, initialTab = 'appearance' }) {
               className={`settings-nav-item ${activePage === 'appearance' ? 'active' : ''}`}
               onClick={() => setActivePage('appearance')}
             >
-              <span className="settings-nav-icon">🎨</span>
+              <FaSlidersH aria-label="Appearance" className="settings-nav-icon" />
               Appearance
             </button>
             <button 
               className={`settings-nav-item ${activePage === 'database' ? 'active' : ''}`}
               onClick={() => setActivePage('database')}
             >
-              <span className="settings-nav-icon">🗄️</span>
+              <FaDatabase aria-label="Database" className="settings-nav-icon" />
               Database
             </button>
             <button 
               className={`settings-nav-item ${activePage === 'apiKeys' ? 'active' : ''}`}
               onClick={() => setActivePage('apiKeys')}
             >
-              <span className="settings-nav-icon">🔑</span>
+              <FaKey aria-label="API Keys" className="settings-nav-icon" />
               API Keys
             </button>
             <button 
               className={`settings-nav-item ${activePage === 'helpFaq' ? 'active' : ''}`}
               onClick={() => setActivePage('helpFaq')}
             >
-              <span className="settings-nav-icon">❓</span>
+              <FaQuestionCircle aria-label="Help" className="settings-nav-icon" />
               Help & FAQ
             </button>
           </nav>


### PR DESCRIPTION
## Summary
- add `react-icons` dependency
- replace emoji spans with accessible icons in multiple components
- update pages and menus to use new icon library

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa7e10908832c81e97256be6de3cf