### PR TITLE
Add configurable API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,15 @@ AudioChat is an AI-powered audio engineering assistant that helps you edit, mix,
    ```
    npm install
    ```
+2. Configure environment variables by copying `.env.example` to `.env` and
+   adjusting `REACT_APP_API_BASE` if your backend is hosted elsewhere.
 
-2. Start the development server:
+3. Start the development server:
    ```
    npm start
    ```
 
-3. Open your browser and navigate to `http://localhost:3000`
+4. Open your browser and navigate to `http://localhost:3000`
 
 ## Usage
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,5 @@ SUPABASE_ANON_KEY=
 PORT=8000
 HOST=0.0.0.0
 DEBUG=True
+# Frontend settings
+REACT_APP_API_BASE=/api

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.NODE_ENV === 'production' 
-    ? '/api' 
-    : 'http://localhost:8000/api',
+  baseURL: process.env.REACT_APP_API_BASE || '/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/services/authenticatedApi.js
+++ b/src/services/authenticatedApi.js
@@ -4,9 +4,7 @@ import authService from './auth';
 
 // Create an authenticated API instance
 const createAuthenticatedApi = async () => {
-  const baseURL = process.env.NODE_ENV === 'production' 
-    ? '/api' 
-    : 'http://localhost:8000/api';
+  const baseURL = process.env.REACT_APP_API_BASE || '/api';
   
   let headers = {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- set up REACT_APP_API_BASE variable in backend/.env.example
- use REACT_APP_API_BASE in api clients
- describe env variable in Frontend Setup instructions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa7d58760832c98d8533904f50549