### PR TITLE
Improve accessibility with aria labels

### DIFF
--- a/src/components/AudioEditor.js
+++ b/src/components/AudioEditor.js
@@ -180,9 +180,10 @@ function AudioEditor({ audioUrl, onSegmentSelect, onExportClick }) {
     <div className="audio-editor">
       <div className="editor-controls">
         <div className="playback-controls">
-          <button 
+          <button
             className="play-button"
             onClick={togglePlayPause}
+            aria-label={isPlaying ? 'Pause playback' : 'Play selection'}
           >
             {isPlaying ? '⏸️' : '▶️'}
           </button>

--- a/src/components/AudioPlayer.js
+++ b/src/components/AudioPlayer.js
@@ -84,9 +84,10 @@ function AudioPlayer({ audioUrl, waveformData, isProcessed = false, title }) {
       />
       
       <div className="player-controls">
-        <button 
-          className={`play-button ${isPlaying ? 'playing' : ''}`} 
+        <button
+          className={`play-button ${isPlaying ? 'playing' : ''}`}
           onClick={togglePlay}
+          aria-label={isPlaying ? 'Pause' : 'Play'}
         >
           {isPlaying ? (
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/AudioRecorder.js
+++ b/src/components/AudioRecorder.js
@@ -103,27 +103,30 @@ function AudioRecorder({ onAudioRecorded }) {
           </div>
           <AudioVisualizer isRecording={isRecording} audioStream={audioStream} />
           <div className="recording-buttons">
-            <button 
-              className="recording-button cancel" 
+            <button
+              className="recording-button cancel"
               onClick={cancelRecording}
               title="Cancel recording"
+              aria-label="Cancel recording"
             >
               ✕
             </button>
-            <button 
-              className="recording-button stop" 
+            <button
+              className="recording-button stop"
               onClick={stopRecording}
               title="Stop recording"
+              aria-label="Stop recording"
             >
               ■
             </button>
           </div>
         </div>
       ) : (
-        <button 
-          className="mic-button" 
+        <button
+          className="mic-button"
           onClick={startRecording}
           title="Start voice recording"
+          aria-label="Start voice recording"
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path>

--- a/src/components/ChatSidebar.js
+++ b/src/components/ChatSidebar.js
@@ -110,10 +110,11 @@ function ChatSidebar({ onSelectChat, activeChat }) {
     <div className="chat-sidebar">
       <div className="sidebar-header">
         <h2>Chats</h2>
-        <button 
+        <button
           className="new-chat-icon-button"
           onClick={() => setIsCreatingChat(true)}
           title="New Chat"
+          aria-label="New Chat"
         >
           +
         </button>
@@ -171,10 +172,11 @@ function ChatSidebar({ onSelectChat, activeChat }) {
                   <span className="chat-item-date">{chat.date}</span>
                 </div>
               </div>
-              <button 
+              <button
                 className="delete-chat-button"
                 onClick={(e) => deleteChat(e, chat.id)}
                 title="Delete chat"
+                aria-label="Delete chat"
               >
                 ×
               </button>

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -46,15 +46,16 @@ function MessageList({ messages, isLoading }) {
           <div className="message-bubble">
             <div className="message-content">
               {message.content}
-              {message.audioUrl && (
-                <button 
+                {message.audioUrl && (
+                <button
                   className={`audio-play-button ${playingAudio === message.id ? 'playing' : ''}`}
                   onClick={() => handlePlayAudio(message.audioUrl, message.id)}
                   title={playingAudio === message.id ? "Stop audio" : "Play audio"}
+                  aria-label={playingAudio === message.id ? 'Stop audio' : 'Play audio'}
                 >
                   {playingAudio === message.id ? '■' : '▶'}
                 </button>
-              )}
+                )}
             </div>
             <div className="message-meta">
               {message.model && `${message.model} • `}

--- a/src/components/UserFiles.js
+++ b/src/components/UserFiles.js
@@ -137,6 +137,7 @@ function UserFiles({ onFileSelect }) {
                   onClick={() => handleDeleteFile(file.file_id)}
                   className="delete-button"
                   title="Delete file"
+                  aria-label="Delete file"
                 >
                   🗑️
                 </button>

--- a/src/components/pages/SettingsPage.js
+++ b/src/components/pages/SettingsPage.js
@@ -68,7 +68,7 @@ function SettingsPage({ onClose, initialTab = 'appearance' }) {
               {activePage === 'apiKeys' && 'API Keys'}
               {activePage === 'helpFaq' && 'Help & FAQ'}
             </h3>
-            <button className="close-button" onClick={onClose}>×</button>
+            <button className="close-button" onClick={onClose} aria-label="Close settings">×</button>
           </div>
           <div className="settings-body">
             {renderActivePage()}


### PR DESCRIPTION
## Summary
- add `aria-label` to the AudioPlayer play button
- add `aria-label` to new-chat and delete buttons in the sidebar
- add descriptive `aria-label`s for recording controls and message audio playback
- ensure dialog close and other icon buttons have accessible text

## Testing
- `npm test --silent --run --colors` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aafa9f5d4832c9ab37a1e9970a54c