### PR TITLE
Add aria-label for textarea

### DIFF
--- a/src/components/MessageInput.js
+++ b/src/components/MessageInput.js
@@ -42,6 +42,7 @@ function MessageInput({ onSend, disabled }) {
       <textarea
         ref={textareaRef}
         value={message}
+        aria-label="Message input"
         onChange={(e) => {
           setMessage(e.target.value);
           adjustTextareaHeight();


### PR DESCRIPTION
## Summary
- improve accessibility of message textarea by adding an aria-label

## Testing
- `cd backend && pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aafb044b0832c9508d7d681ceb165