### PR TITLE
Add spinner during audio processing

### DIFF
--- a/src/components/AudioProcessingInterface.css
+++ b/src/components/AudioProcessingInterface.css
@@ -113,6 +113,14 @@
   cursor: not-allowed;
 }
 
+/* Wrapper for process button and spinner */
+.process-button-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
 .processing-results {
   background-color: hsl(var(--card));
   border-radius: var(--radius);
@@ -516,6 +524,11 @@
   .processing-actions {
     flex-direction: column;
     gap: 0.75rem;
+  }
+
+  .process-button-wrapper {
+    flex-direction: column;
+    align-items: flex-start;
   }
   
   .save-button, .new-processing-button {

--- a/src/components/AudioProcessingInterface.js
+++ b/src/components/AudioProcessingInterface.js
@@ -13,6 +13,7 @@ import { useAuth } from '../context/AuthContext';
 import uploadService from '../services/upload';
 import { getAudioWaveform } from '../services/authenticatedApi';
 import processingHistoryService from '../services/processingHistory';
+import Spinner from './Spinner';
 import './AudioProcessingInterface.css';
 
 function AudioProcessingInterface() {
@@ -311,13 +312,16 @@ function AudioProcessingInterface() {
                 </div>
               </div>
               
-              <button 
-                className="process-button"
-                onClick={handleProcessAudio}
-                disabled={isProcessing || !processingInstructions.trim()}
-              >
-                {isProcessing ? 'Processing...' : 'Process Audio'}
-              </button>
+              <div className="process-button-wrapper">
+                <button
+                  className="process-button"
+                  onClick={handleProcessAudio}
+                  disabled={isProcessing || !processingInstructions.trim()}
+                >
+                  {isProcessing ? 'Processing...' : 'Process Audio'}
+                </button>
+                {isProcessing && <Spinner size={24} />}
+              </div>
             </div>
             
             {processedAudio && (

--- a/src/components/Spinner.css
+++ b/src/components/Spinner.css
@@ -1,0 +1,6 @@
+.spinner {
+  border: 4px solid var(--muted);
+  border-top: 4px solid var(--primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import './Spinner.css';
+
+function Spinner({ size = 24 }) {
+  return <div className="spinner" style={{ width: size, height: size }}></div>;
+}
+
+export default Spinner;


### PR DESCRIPTION
## Summary
- add reusable `Spinner` component for loading animations
- wrap Process Audio button and show Spinner while processing
- style spinner wrapper for both desktop and mobile

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aafb19ea4832cbdfdf3239b63a9a8