### PR TITLE
Add copy button to messages

### DIFF
--- a/src/components/MessageList.css
+++ b/src/components/MessageList.css
@@ -144,3 +144,21 @@
     opacity: 1;
   }
 }
+
+/* Copy text button */
+.copy-button {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-left: 8px;
+  font-size: 0.75rem;
+  vertical-align: middle;
+  transition: background 0.2s ease;
+}
+
+.copy-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+}

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -46,8 +46,15 @@ function MessageList({ messages, isLoading }) {
           <div className="message-bubble">
             <div className="message-content">
               {message.content}
+              <button
+                className="copy-button"
+                onClick={() => navigator.clipboard.writeText(message.content)}
+                title="Copy text"
+              >
+                Copy
+              </button>
               {message.audioUrl && (
-                <button 
+                <button
                   className={`audio-play-button ${playingAudio === message.id ? 'playing' : ''}`}
                   onClick={() => handlePlayAudio(message.audioUrl, message.id)}
                   title={playingAudio === message.id ? "Stop audio" : "Play audio"}


### PR DESCRIPTION
## Summary
- add a copy-to-clipboard button for each message
- style the new copy button

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aafb40fb4832cb9ff770d74bce689