### PR TITLE
Implement copy button for chat messages

### DIFF
--- a/src/components/MessageList.css
+++ b/src/components/MessageList.css
@@ -144,3 +144,18 @@
     opacity: 1;
   }
 }
+
+.copy-button {
+  background: none;
+  border: none;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  margin-left: 8px;
+  font-size: 0.75rem;
+  padding: 0 4px;
+  transition: color 0.2s;
+}
+
+.copy-button:hover {
+  color: var(--foreground);
+}

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -44,8 +44,8 @@ function MessageList({ messages, isLoading }) {
             {message.role === 'user' ? 'U' : 'AI'}
           </div>
           <div className="message-bubble">
-            <div className="message-content">
-              {message.content}
+          <div className="message-content">
+              <span className="message-text">{message.content}</span>
                 {message.audioUrl && (
                 <button
                   className={`audio-play-button ${playingAudio === message.id ? 'playing' : ''}`}
@@ -56,7 +56,15 @@ function MessageList({ messages, isLoading }) {
                   {playingAudio === message.id ? '■' : '▶'}
                 </button>
                 )}
-            </div>
+                <button
+                  className="copy-button"
+                  onClick={() => navigator.clipboard.writeText(message.content)}
+                  aria-label="Copy message"
+                  title="Copy message"
+                >
+                  Copy
+                </button>
+          </div>
             <div className="message-meta">
               {message.model && `${message.model} • `}
               {message.timestamp.toLocaleTimeString()}


### PR DESCRIPTION
## Summary
- add copy-to-clipboard button on each message
- style copy button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aae599e7c832c81af55fff8c733d2