### PR TITLE
Fix home page navigation and add landing content

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -288,24 +288,8 @@ function AppContent() {
             </div>
           </div>
         ) : (
-          // Show chats page by default instead of HomePage
-          <div className="page-container">
-            <div className="page-header">
-              <h2 className="page-title">Chats</h2>
-            </div>
-            <div className="chat-container">
-              <ChatSidebar 
-                onSelectChat={handleSelectChat}
-                activeChat={activeChat}
-              />
-              <ChatInterface 
-                selectedLLM={selectedLLM}
-                messages={messages}
-                setMessages={setMessages}
-                activeChat={activeChat}
-              />
-            </div>
-          </div>
+          // Show home page when no specific page is active
+          <HomePage />
         )}
       </MainLayout>
     </React.Suspense>

--- a/src/components/HomePage.css
+++ b/src/components/HomePage.css
@@ -1,3 +1,4 @@
+
 .home-page {
   display: flex;
   flex-direction: column;
@@ -24,29 +25,35 @@
   margin-bottom: 30px;
 }
 
-.redirecting-message {
+.home-description {
   font-size: 1rem;
-  color: #888;
-  margin-top: 20px;
-  font-style: italic;
+  color: #666;
+  margin-bottom: 20px;
 }
 
-.loading-container {
+.quick-links {
   display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
   justify-content: center;
-  margin-top: 20px;
 }
 
-.loading-spinner {
-  border: 4px solid rgba(0, 0, 0, 0.1);
-  border-radius: 50%;
-  border-top: 4px solid #4a90e2;
-  width: 40px;
-  height: 40px;
-  animation: spin 1s linear infinite;
+.quick-link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 500;
+  height: 2.5rem;
+  padding: 0 1rem;
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+.quick-link-button:hover {
+  background-color: hsl(var(--primary) / 0.8);
 }

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -1,45 +1,42 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import './HomePage.css';
 
 const HomePage = () => {
   // Function to handle navigation to different pages
   const handleNavigation = (page) => {
-    console.log('HomePage: Navigating to', page); // Debug log
-    // Dispatch a custom event to notify App.js about the navigation
-    window.dispatchEvent(new CustomEvent('navigationChange', { detail: { page } }));
+    window.dispatchEvent(
+      new CustomEvent('navigationChange', { detail: { page } })
+    );
   };
 
-  // Automatically navigate to chats page when component mounts
-  useEffect(() => {
-    // Navigate immediately
-    handleNavigation('chats');
-    
-    // If that doesn't work, try again after a short delay
-    const timer = setTimeout(() => {
-      handleNavigation('chats');
-    }, 100);
-    
-    // And try one more time after a longer delay
-    const timer2 = setTimeout(() => {
-      handleNavigation('chats');
-    }, 500);
-    
-    return () => {
-      clearTimeout(timer);
-      clearTimeout(timer2);
-    };
-  }, []);
-
   return (
-    <div className="home-page">
+    <div className="home-page page-container">
       <header className="home-header">
         <h1 className="home-title">Welcome to AudioChat</h1>
         <p className="home-subtitle">Your AI-powered audio engineering assistant</p>
-        <p className="redirecting-message">Redirecting to chat interface...</p>
       </header>
-      
-      <div className="loading-container">
-        <div className="loading-spinner"></div>
+      <p className="home-description">
+        Choose one of the options below to get started.
+      </p>
+      <div className="quick-links">
+        <button
+          className="quick-link-button"
+          onClick={() => handleNavigation('chats')}
+        >
+          Open Chats
+        </button>
+        <button
+          className="quick-link-button"
+          onClick={() => handleNavigation('audio')}
+        >
+          Audio Processing
+        </button>
+        <button
+          className="quick-link-button"
+          onClick={() => handleNavigation('settings')}
+        >
+          Settings
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- avoid automatic redirect from home page
- show new dashboard-style landing content with quick links
- update styles for the new home page
- default to home page when no specific page is active

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aba4ed76c832c8f2c9946f2f0ad49