### PR TITLE
Improve settings page style

### DIFF
--- a/src/components/pages/Pages.css
+++ b/src/components/pages/Pages.css
@@ -94,6 +94,7 @@
 
 /* Settings page specific styles */
 .settings-container {
+  display: flex;
   background-color: var(--card);
   border-radius: var(--radius);
   border: 1px solid var(--border);
@@ -102,6 +103,65 @@
   width: 100%;
   max-width: 900px;
   margin: 0 auto;
+}
+
+.settings-sidebar {
+  width: 220px;
+  border-right: 1px solid var(--border);
+  background-color: var(--card);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-sidebar h2 {
+  margin: 0 0 1rem 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--card-foreground);
+}
+
+.settings-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border-radius: var(--radius);
+  background-color: transparent;
+  color: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  border: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.settings-nav-item:hover {
+  background-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.settings-nav-item.active {
+  background-color: var(--accent);
+  color: var(--accent-foreground);
+  font-weight: 600;
+}
+
+.settings-nav-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
 }
 
 .settings-header {
@@ -113,7 +173,7 @@
   border-bottom: 1px solid var(--border);
 }
 
-.settings-header h2 {
+.settings-header h3 {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
@@ -173,6 +233,10 @@
   padding: 1.5rem;
   overflow-y: auto;
   max-height: calc(100vh - 200px);
+}
+
+.settings-body {
+  padding-top: 1rem;
 }
 
 .settings-section {

--- a/src/components/pages/SettingsPage.js
+++ b/src/components/pages/SettingsPage.js
@@ -28,11 +28,10 @@ function SettingsPage({ onClose, initialTab = 'appearance' }) {
 
   return (
     <div className="settings-container">
-      <div>
-        <div className="settings-sidebar">
+      <div className="settings-sidebar">
           <h2>{t('settings.title')}</h2>
           <nav className="settings-nav">
-            <button 
+            <button
               className={`settings-nav-item ${activePage === 'appearance' ? 'active' : ''}`}
               onClick={() => setActivePage('appearance')}
             >
@@ -61,8 +60,8 @@ function SettingsPage({ onClose, initialTab = 'appearance' }) {
               {t('settings.helpFaq')}
             </button>
           </nav>
-        </div>
-        <div className="settings-content">
+      </div>
+      <div className="settings-content">
           <div className="settings-header">
             <h3>
               {activePage === 'appearance' && t('settings.header.appearance')}
@@ -70,12 +69,11 @@ function SettingsPage({ onClose, initialTab = 'appearance' }) {
               {activePage === 'apiKeys' && t('settings.header.apiKeys')}
               {activePage === 'helpFaq' && t('settings.header.helpFaq')}
             </h3>
-            <button className="close-button" onClick={onClose} aria-label="Close settings">×</button>
+            <button className="settings-close" onClick={onClose} aria-label="Close settings">×</button>
           </div>
           <div className="settings-body">
             {renderActivePage()}
           </div>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render settings sidebar and content side-by-side
- add layout and navigation styling for settings page
- style close button and body area

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbb5cd7c0832cae7a4d84d6d5e22e